### PR TITLE
libelfin is a submodule; timestamps for all entries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "roms/seabios"]
 	path = roms/seabios
 	url = git://git.qemu.org/seabios.git/
+[submodule "libelfin"]
+	path = libelfin
+	url = https://github.com/aclements/libelfin.git

--- a/README.md
+++ b/README.md
@@ -8,18 +8,15 @@ files and implements a suite of analyses.
 
 N.B.: Don't confuse QEMU's 'trace' features with mtrace.
 
-
 Dependencies
 ------------
 
-mscan depends on libelfin, which can be found at
+mscan depends on libelfin, which is a submodule of mtrace. Simply
+initialize the submodule, update it, and build it:
 
-    git clone https://github.com/aclements/libelfin.git
-
-We recommend cloning and building libelfin next to the mtrace
-repository, as mtrace will find it automatically.  Alternatively, you
-can `make install` libelfin to install it system-wide.
-
+    git submodule init libelfin
+    git submodule update libelfin
+    cd libelfin && make
 
 Building
 --------

--- a/mtrace-magic.h
+++ b/mtrace-magic.h
@@ -69,6 +69,7 @@ typedef enum {
  */
 struct mtrace_entry_header {
     mtrace_entry_t type;
+    double timestamp;
     uint16_t size;
     uint16_t cpu;
     uint64_t access_count;

--- a/mtrace-tools/Makefile
+++ b/mtrace-tools/Makefile
@@ -4,7 +4,7 @@ QEMUDIR = ..
 INSTDIR = /usr/local/bin
 PYFLAKES = $(shell which pyflakes)
 # Search for a local check-out of libelfin
-export PKG_CONFIG_PATH += :../../libelfin/elf:../../libelfin/dwarf
+export PKG_CONFIG_PATH += :../libelfin/elf:../libelfin/dwarf
 
 ifneq ($(shell PKG_CONFIG_PATH=${PKG_CONFIG_PATH} pkg-config --print-errors 'libdwarf++ >= 0.1'; echo $$?),0)
 $(error Please install libelfin from https://github.com/aclements/libelfin)

--- a/mtrace-tools/json.hh
+++ b/mtrace-tools/json.hh
@@ -57,6 +57,7 @@ static inline JsonObject *jsonify(uint64_t value);
 static inline JsonObject *jsonify(uint8_t value);
 static inline JsonObject *jsonify(int value);
 static inline JsonObject *jsonify(float value);
+static inline JsonObject *jsonify(double value);
 
 class JsonString : public JsonObject {
     virtual bool write_to(ostream *o, int level, JsonObject *parent) {
@@ -148,6 +149,26 @@ private:
 
 static inline JsonObject *jsonify(float value) {
     return new JsonFloat(value);
+}
+
+class JsonDouble : public JsonObject {
+public:
+    virtual bool write_to(ostream *o, int level, JsonObject *parent) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%f", value_);
+        *o << buf;
+        return true;
+    }
+
+private:
+    JsonDouble(double value) : value_(value) {}
+    double value_;
+
+    friend JsonObject *jsonify(double value);
+};
+
+static inline JsonObject *jsonify(double value) {
+    return new JsonDouble(value);
 }
 
 class JsonDict : public JsonObject {

--- a/mtrace-tools/m2json.cc
+++ b/mtrace-tools/m2json.cc
@@ -11,10 +11,11 @@ static JsonList* thelist;
 
 static void handle_entry(union mtrace_entry *entry)
 {
-        JsonDict* je = JsonDict::create();
+    JsonDict* je = JsonDict::create();
 
-        je->put("cpu", entry->h.cpu);
-        je->put("access_count", entry->h.access_count);
+    je->put("timestamp", entry->h.timestamp);
+    je->put("cpu", entry->h.cpu);
+    je->put("access_count", entry->h.access_count);
 
 	switch(entry->h.type) {
 	case mtrace_entry_label:

--- a/mtrace-tools/m2text.c
+++ b/mtrace-tools/m2text.c
@@ -38,6 +38,9 @@ static void print_entry(union mtrace_entry *entry)
 		[mtrace_task_exit]   = "exit",
 	};
 
+    // Printing the timestamp for all types
+    printf("(%f) ", entry->h.timestamp);
+
 	switch(entry->h.type) {
 	case mtrace_entry_label:
 		printf("%-3s [%-3u  %16s  %016"PRIx64"  %016"PRIx64"  %016"PRIx64"  %016"PRIx64"  %016"PRIx64"]\n",


### PR DESCRIPTION
Two big changes in this pull request:

1) libelfin is a submodule of mtrace. The readme has been updated to reflect this.
2) All mtrace entries have timestamps. Both m2text and m2json have been updated to reflect this.
