### PR TITLE
Patch to record Program Counter (PC)

### DIFF
--- a/cpu-all.h
+++ b/cpu-all.h
@@ -976,6 +976,7 @@ extern RAMBlock *qemu_ramblock_from_host(void *ptr);
 
 void REGPARM mtrace_st(target_ulong host_addr, target_ulong guest_addr, char bytes, void *retaddr);
 void REGPARM mtrace_ld(target_ulong host_addr, target_ulong guest_addr, char bytes, void *retaddr);
+void mtrace_guest_pc(target_ulong pc);
 void REGPARM mtrace_tcg_st(target_ulong host_addr, target_ulong guest_addr, char bytes);
 void REGPARM mtrace_tcg_ld(target_ulong host_addr, target_ulong guest_addr, char bytes);
 void mtrace_io_write(void *cb, target_phys_addr_t host_addr, target_ulong guest_addr, 

--- a/mtrace.c
+++ b/mtrace.c
@@ -63,6 +63,8 @@ static int mtrace_count_disable[255];
 static uint64_t mtrace_call_stack[255];
 static int mtrace_call_stack_tagvalid[255];
 
+static uint64_t MTRACE_GUEST_PC = 0;
+
 struct mtrace_call_stack_info
 {
     uint64_t tag;
@@ -334,7 +336,8 @@ static void mtrace_access_dump(mtrace_access_t type, target_ulong host_addr,
     entry.h.access_count = access_count;
     entry.h.ts = 0; /* Unimplemented timestamp */
     entry.access_type = type;
-    entry.pc = mtrace_get_pc((unsigned long)retaddr);
+    // entry.pc = mtrace_get_pc((unsigned long)retaddr);
+    entry.pc = MTRACE_GUEST_PC;
     entry.host_addr = host_addr;
     entry.guest_addr = guest_addr;
     entry.traffic = traffic;
@@ -444,6 +447,11 @@ void REGPARM mtrace_tcg_st(target_ulong host_addr, target_ulong guest_addr,
                            char bytes)
 {
     mtrace_st(host_addr, guest_addr, bytes, MTRACE_GETPC());
+}
+
+void mtrace_guest_pc(target_ulong pc)
+{
+	MTRACE_GUEST_PC = pc;
 }
 
 void REGPARM mtrace_ld(target_ulong host_addr, target_ulong guest_addr,

--- a/target-i386/helper.h
+++ b/target-i386/helper.h
@@ -222,5 +222,6 @@ DEF_HELPER_0(mtrace_inst_exec, void)
 DEF_HELPER_2(mtrace_inst_call, void, tl, tl)
 DEF_HELPER_1(mtrace_inst_ret, void, tl)
 DEF_HELPER_0(mtrace_insn_count, void)
+DEF_HELPER_1(mtrace_guest_pc, void, tl);
 
 #include "def-helper.h"

--- a/target-i386/op_helper.c
+++ b/target-i386/op_helper.c
@@ -5687,6 +5687,11 @@ void helper_mtrace_inst_call(target_ulong target_pc, target_ulong return_pc)
     mtrace_inst_call(target_pc, return_pc, 0);
 }
 
+void HELPER(mtrace_guest_pc)(target_ulong pc)
+{
+	mtrace_guest_pc(pc);
+}
+
 void helper_mtrace_inst_ret(target_ulong target_pc)
 {
     mtrace_inst_call(target_pc, 0, 1);

--- a/target-i386/translate.c
+++ b/target-i386/translate.c
@@ -4072,6 +4072,7 @@ static target_ulong disas_insn(DisasContext *s, target_ulong pc_start)
     if (unlikely(qemu_loglevel_mask(CPU_LOG_TB_OP)))
         tcg_gen_debug_insn_start(pc_start);
     s->pc = pc_start;
+    gen_helper_mtrace_guest_pc(tcg_const_i64(pc_start));
     prefixes = 0;
     aflag = s->code32;
     dflag = s->code32;


### PR DESCRIPTION
Simple, efficient and a fast hack to record program counter 
of every instruction in a program while executing it in qemu-mtrace.
