### PR TITLE
Enable target sparc-softmmu

### DIFF
--- a/mtrace.c
+++ b/mtrace.c
@@ -510,12 +510,12 @@ void mtrace_io_read(void *cb, target_phys_addr_t ram_addr,
     /* Nothing to do.. */
 }
 
-static inline uint64_t mtrace_get_percore_tsc(CPUX86State *env)
+static inline uint64_t mtrace_get_percore_tsc(CPUState *env)
 {
     return mtrace_inst_count[env->cpu_index];
 }
 
-static inline uint64_t mtrace_get_global_tsc(CPUX86State *env)
+static inline uint64_t mtrace_get_global_tsc(CPUState *env)
 {
     uint64_t t;
     int i;
@@ -526,7 +526,7 @@ static inline uint64_t mtrace_get_global_tsc(CPUX86State *env)
     return t;
 }
 
-void mtrace_lock_start(CPUX86State *env)
+void mtrace_lock_start(CPUState *env)
 {
     if (!mtrace_lock_trace)
 	return;
@@ -547,7 +547,7 @@ void mtrace_lock_start(CPUX86State *env)
     mtrace_lock_active[env->cpu_index] = 1;
 }
 
-void mtrace_lock_stop(CPUX86State *env)
+void mtrace_lock_stop(CPUState *env)
 {
     if (!mtrace_lock_trace)
 	return;
@@ -667,7 +667,7 @@ static void mtrace_entry_register(target_ulong entry_addr, target_ulong type,
 	 *
 	 * A simple solution is probably to log multiple mtrace_label_entrys.
 	 */
-	r = mtrace_host_addr(entry.label.guest_addr, &entry.label.host_addr);
+	r = mtrace_host_addr(entry.label.guest_addr, (target_ulong*) &entry.label.host_addr);
 	if (r) {
 	    fprintf(stderr, "mtrace_entry_register: mtrace_host_addr failed (%"PRIx64")\n", 
 		    entry.label.guest_addr);

--- a/qemu-doc.texi
+++ b/qemu-doc.texi
@@ -224,7 +224,7 @@ VGA BIOS.
 QEMU uses YM3812 emulation by Tatsuyuki Satoh.
 
 QEMU uses GUS emulation (GUSEMU32 @url{http://www.deinmeister.de/gusemu/})
-by Tibor "TS" Schütz.
+by Tibor "TS" Schutz.
 
 Not that, by default, GUS shares IRQ(7) with parallel ports and so
 qemu must be told to not have parallel ports to have working GUS

--- a/target-sparc/cpu.h
+++ b/target-sparc/cpu.h
@@ -36,6 +36,8 @@
 #define ELF_MACHINE     EM_SPARCV9
 #endif
 
+#define R_CS 0
+
 /*#define EXCP_INTERRUPT 0x100*/
 
 /* trap definitions */
@@ -323,12 +325,21 @@ struct QEMUFile;
 void cpu_put_timer(struct QEMUFile *f, CPUTimer *s);
 void cpu_get_timer(struct QEMUFile *f, CPUTimer *s);
 
+typedef struct SegmentCache {
+    uint32_t selector;
+    target_ulong base;
+    uint32_t limit;
+    uint32_t flags;
+} SegmentCache;
+
 typedef struct CPUSPARCState {
     target_ulong gregs[8]; /* general registers */
     target_ulong *regwptr; /* pointer to current register window */
     target_ulong pc;       /* program counter */
     target_ulong npc;      /* next program counter */
     target_ulong y;        /* multiply/divide register */
+    target_ulong eip;      /* */
+    SegmentCache segs[1];  /* selector values */
 
     /* emulator internal flags handling */
     target_ulong cc_src, cc_src2;


### PR DESCRIPTION
Some changes added to enable the generation of the sparc-softmmu target.

Changes now enable:
./configure --target-list="sparc-softmmu"  --disable-kvm --audio-card-list="" --disable-vnc-jpeg --disable-vnc-png --disable-strip
make

Tests:
I checked that the x86_64-softmmu target is still generated:
./configure --target-list="x86_64-softmmu"  --disable-kvm --audio-card-list="" --disable-vnc-jpeg --disable-vnc-png --disable-strip
make

Modified files:
mtrace.c
target-sparc/cpu.h
* Modified to enable compilation of sparc-softmmu target

qemu-doc.texi
* Modified to remove the following error when making:
  GEN   qemu.1
  Unescaped left brace in regex is deprecated, passed through in regex;
  marked by <-- HERE in m/^\@strong{ <-- HERE (.*)}$/ at
  texi2pod.pl line
  313.
  qemu.pod around line 95: Non-ASCII character seen before =encoding in
  'Sch�tz.'. Assuming UTF-8
  POD document had syntax errors at /usr/bin/pod2man line 68.
  Makefile:297: recipe for target 'qemu.1' failed
  make: *** [qemu.1] Error 255
  make: *** Deleting file 'qemu.1